### PR TITLE
Add the support of Carthage

### DIFF
--- a/GestureRecognizerClosures.xcodeproj/xcshareddata/xcschemes/GestureRecognizerClosures.xcscheme
+++ b/GestureRecognizerClosures.xcodeproj/xcshareddata/xcschemes/GestureRecognizerClosures.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A0E0A2DA1B8D186F00E9F7D0"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Then, run the following command:
 $ pod install
 ```
 
+### Use Carthage
+You can use [Carthage](github.com/carthage/carthage) to install `GestureRecognizerClosures ` by adding it to your `Cartfile`:
+
+```
+github "marcbaldwin/GestureRecognizerClosures"
+```
+
+
 ## Updating
 
 ### Use CocoaPods


### PR DESCRIPTION
There was errors while building with carthage because he was trying to compile the target GestureRecogniserClosuresTests. Simply kept this target for Test.